### PR TITLE
remove year redirect for grafanaconline

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -5,10 +5,10 @@ layout: redirect
 <head>
     <meta charset="utf-8">
     <title>Redirecting to https://grafana.com/about/events/grafanacon/2021/</title>
-    <meta http-equiv="refresh" content="0; URL=https://grafana.com/about/events/grafanacon/2021/">
-    <link rel="canonical" href="https://grafana.com/about/events/grafanacon/2021/">
+    <meta http-equiv="refresh" content="0; URL=https://grafana.com/about/events/grafanacon/">
+    <link rel="canonical" href="https://grafana.com/about/events/grafanacon/">
 </head>
 <body>
-    <p><a href="https://grafana.com/about/events/grafanacon/2021/">This page has moved to https://grafana.com/about/events/grafanacon/2021/.</a></p>
+    <p><a href="https://grafana.com/about/events/grafanacon/">This page has moved to https://grafana.com/about/events/grafanacon/.</a></p>
 </body>
 </html>


### PR DESCRIPTION
We handle the https://grafana.com/about/events/grafanacon/ redirect on the website end.